### PR TITLE
Make CPS counters not tied to frame rate (1.8 + 1.7)

### DIFF
--- a/1.7.10/src/main/java/dev/cloudmc/Cloud.java
+++ b/1.7.10/src/main/java/dev/cloudmc/Cloud.java
@@ -12,6 +12,7 @@ import dev.cloudmc.feature.option.OptionManager;
 import dev.cloudmc.feature.setting.SettingManager;
 import dev.cloudmc.gui.hudeditor.HudEditorLoader;
 import dev.cloudmc.gui.hudeditor.impl.HudEditor;
+import dev.cloudmc.helpers.CpsHelper;
 import dev.cloudmc.helpers.font.FontHelper;
 import net.minecraft.client.Minecraft;
 import cpw.mods.fml.common.Mod;
@@ -45,6 +46,7 @@ public class Cloud {
     public HudEditor hudEditor;
     public OptionManager optionManager;
     public FontHelper fontHelper;
+    public CpsHelper cpsHelper;
 
     /**
      * Initializes the client
@@ -52,6 +54,7 @@ public class Cloud {
     @EventHandler
     public void init(FMLInitializationEvent event) throws IOException {
         MinecraftForge.EVENT_BUS.register(this);
+        MinecraftForge.EVENT_BUS.register((cpsHelper = new CpsHelper()));
         Display.setTitle(Cloud.modName + " Client " + Cloud.modVersion);
 
         settingManager = new SettingManager();

--- a/1.7.10/src/main/java/dev/cloudmc/gui/hudeditor/impl/impl/CpsHud.java
+++ b/1.7.10/src/main/java/dev/cloudmc/gui/hudeditor/impl/impl/CpsHud.java
@@ -16,10 +16,6 @@ import net.minecraftforge.client.event.RenderGameOverlayEvent;
 
 public class CpsHud extends HudMod {
 
-    CpsHelper cpsRight = new CpsHelper();
-    CpsHelper cpsLeft = new CpsHelper();
-    private boolean noGuiScreen;
-
     public CpsHud(String name, int x, int y) {
         super(name, x, y);
         setW(60);
@@ -57,7 +53,6 @@ public class CpsHud extends HudMod {
 
     @SubscribeEvent
     public void onRender2D(RenderGameOverlayEvent.Pre.Text e) {
-        noGuiScreen = Cloud.INSTANCE.mc.currentScreen == null;
         if (Cloud.INSTANCE.modManager.getMod(getName()).isToggled() && !(Cloud.INSTANCE.mc.currentScreen instanceof HudEditor)) {
             if (isModern()) {
                 if (isBackground()) {
@@ -101,10 +96,10 @@ public class CpsHud extends HudMod {
     }
 
     private int getLeftCPS() {
-        return cpsLeft.getCPS(0, noGuiScreen);
+        return Cloud.INSTANCE.cpsHelper.getCPS(0);
     }
 
     private int getRightCPS() {
-        return cpsRight.getCPS(1, noGuiScreen);
+        return Cloud.INSTANCE.cpsHelper.getCPS(1);
     }
 }

--- a/1.7.10/src/main/java/dev/cloudmc/gui/hudeditor/impl/impl/keystrokes/keys/MouseKey.java
+++ b/1.7.10/src/main/java/dev/cloudmc/gui/hudeditor/impl/impl/keystrokes/keys/MouseKey.java
@@ -14,10 +14,6 @@ import org.lwjgl.input.Mouse;
 
 public class MouseKey {
 
-    private CpsHelper cps = new CpsHelper();
-
-    private boolean noGuiScreen;
-
     public void renderKey(int x, int y, int width, int height, boolean modern, int mouseButton, int color, int fontColor, boolean background, boolean cps) {
         boolean mouseDown;
         if(Cloud.INSTANCE.mc.currentScreen == null) {
@@ -26,8 +22,6 @@ public class MouseKey {
         else {
             mouseDown = false;
         }
-
-        noGuiScreen = Cloud.INSTANCE.mc.currentScreen == null;
 
         if (modern) {
             if (background) {
@@ -78,6 +72,6 @@ public class MouseKey {
     }
 
     private int getCPS(int mouseButton) {
-        return cps.getCPS(mouseButton, noGuiScreen);
+        return Cloud.INSTANCE.cpsHelper.getCPS(mouseButton);
     }
 }

--- a/1.7.10/src/main/java/dev/cloudmc/helpers/CpsHelper.java
+++ b/1.7.10/src/main/java/dev/cloudmc/helpers/CpsHelper.java
@@ -5,34 +5,38 @@
 
 package dev.cloudmc.helpers;
 
-import org.lwjgl.input.Mouse;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.event.MouseEvent;
 
-import java.util.LinkedList;
-import java.util.Queue;
+import java.util.ArrayList;
+import java.util.List;
 
 public class CpsHelper {
 
-    private final Queue<Long> clicks;
-    private boolean lastClick;
+    private List<Long> leftClicks = new ArrayList<>();
+    private List<Long> rightClicks = new ArrayList<>();
 
-    public CpsHelper(){
-        clicks = new LinkedList<>();
-    }
-
-    private void updateClicks(int mouseButton, boolean shouldAdd){
+    @SubscribeEvent
+    public void onClick(MouseEvent event) {
+        if (Minecraft.getMinecraft().currentScreen != null) return; // don't register cps in GUIs
         long time = System.currentTimeMillis();
 
-        if(Mouse.isButtonDown(mouseButton) != lastClick){
-            lastClick = Mouse.isButtonDown(mouseButton);
-            if(Mouse.isButtonDown(mouseButton) && shouldAdd)
-                clicks.add(time);
-        }
+        if (!event.buttonstate) return;
 
-        clicks.removeIf(e -> e + 1000 < time);
+        if (event.button == 0) leftClicks.add(time);
+        else if (event.button == 1) rightClicks.add(time);
+
+        removeOldClicks(time);
     }
 
-    public int getCPS(int mouseButton, boolean shouldAdd){
-        updateClicks(mouseButton, shouldAdd);
-        return clicks.size();
+    public int getCPS(int mouseButton) {
+        removeOldClicks(System.currentTimeMillis());
+        return mouseButton == 0 ? leftClicks.size() : rightClicks.size();
+    }
+
+    public void removeOldClicks(long currentTime) {
+        leftClicks.removeIf(e -> e + 1000 < currentTime);
+        rightClicks.removeIf(e -> e + 1000 < currentTime);
     }
 }

--- a/1.8.9/src/main/java/dev/cloudmc/Cloud.java
+++ b/1.8.9/src/main/java/dev/cloudmc/Cloud.java
@@ -12,6 +12,7 @@ import dev.cloudmc.feature.option.OptionManager;
 import dev.cloudmc.feature.setting.SettingManager;
 import dev.cloudmc.gui.hudeditor.impl.HudEditor;
 import dev.cloudmc.gui.hudeditor.HudEditorLoader;
+import dev.cloudmc.helpers.CpsHelper;
 import dev.cloudmc.helpers.font.FontHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.common.MinecraftForge;
@@ -46,6 +47,7 @@ public class Cloud {
     public HudEditor hudEditor;
     public OptionManager optionManager;
     public FontHelper fontHelper;
+    public CpsHelper cpsHelper;
 
     /**
      * Initializes the client
@@ -53,6 +55,7 @@ public class Cloud {
     @EventHandler
     public void init(FMLInitializationEvent event) throws IOException {
         MinecraftForge.EVENT_BUS.register(this);
+        MinecraftForge.EVENT_BUS.register((cpsHelper = new CpsHelper()));
         Display.setTitle(Cloud.modName + " Client " + Cloud.modVersion);
 
         settingManager = new SettingManager();

--- a/1.8.9/src/main/java/dev/cloudmc/gui/hudeditor/impl/impl/CpsHud.java
+++ b/1.8.9/src/main/java/dev/cloudmc/gui/hudeditor/impl/impl/CpsHud.java
@@ -16,10 +16,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class CpsHud extends HudMod {
 
-    private CpsHelper cpsRight = new CpsHelper();
-    private CpsHelper cpsLeft = new CpsHelper();
-    private boolean noGuiScreen;
-
     public CpsHud(String name, int x, int y) {
         super(name, x, y);
         setW(60);
@@ -57,7 +53,6 @@ public class CpsHud extends HudMod {
 
     @SubscribeEvent
     public void onRender2D(RenderGameOverlayEvent.Pre.Text e) {
-        noGuiScreen = Cloud.INSTANCE.mc.currentScreen == null;
         if (Cloud.INSTANCE.modManager.getMod(getName()).isToggled() && !(Cloud.INSTANCE.mc.currentScreen instanceof HudEditor)) {
             if (isModern()) {
                 if (isBackground()) {
@@ -101,10 +96,10 @@ public class CpsHud extends HudMod {
     }
 
     private int getLeftCPS() {
-        return cpsLeft.getCPS(0, noGuiScreen);
+        return Cloud.INSTANCE.cpsHelper.getCPS(0);
     }
 
     private int getRightCPS() {
-        return cpsRight.getCPS(1, noGuiScreen);
+        return Cloud.INSTANCE.cpsHelper.getCPS(1);
     }
 }

--- a/1.8.9/src/main/java/dev/cloudmc/gui/hudeditor/impl/impl/keystrokes/keys/MouseKey.java
+++ b/1.8.9/src/main/java/dev/cloudmc/gui/hudeditor/impl/impl/keystrokes/keys/MouseKey.java
@@ -14,10 +14,6 @@ import org.lwjgl.input.Mouse;
 
 public class MouseKey {
 
-    private CpsHelper cps = new CpsHelper();
-
-    private boolean noGuiScreen;
-
     public void renderKey(int x, int y, int width, int height, boolean modern, int mouseButton, int color, int fontColor, boolean background, boolean cps) {
         boolean mouseDown;
         if(Cloud.INSTANCE.mc.currentScreen == null) {
@@ -26,8 +22,6 @@ public class MouseKey {
         else {
             mouseDown = false;
         }
-
-        noGuiScreen = Cloud.INSTANCE.mc.currentScreen == null;
 
         if (modern) {
             if (background) {
@@ -78,6 +72,6 @@ public class MouseKey {
     }
 
     private int getCPS(int mouseButton) {
-        return cps.getCPS(mouseButton, noGuiScreen);
+        return Cloud.INSTANCE.cpsHelper.getCPS(mouseButton);
     }
 }


### PR DESCRIPTION
Fixes #19 
Uses an event instead of checking if the mouse is down to make the cps counters more accurate and not tied to the game's frame rate.