### PR TITLE
Improvements to make it easier to import

### DIFF
--- a/1.7.10/buildscript/forge-1.7.gradle
+++ b/1.7.10/buildscript/forge-1.7.gradle
@@ -7,7 +7,7 @@ group = "dev.cloudmc"
 archivesBaseName = "cloudmc"
 
 minecraft {
-    version = "${project.minecraft_version}-${project.forge_version}"
+    version = "1.7.10-10.13.4.1614-1.7.10"
     runDir = "run"
 	replace '@VERSION@', project.version
 }
@@ -22,9 +22,7 @@ configurations {
     compile.extendsFrom(shade)
 }
 
-if(project.enable_mixin.toBoolean()) {
-	apply from: "buildscript/forge-1.7-mixin.gradle"
-}
+apply from: "buildscript/forge-1.7-mixin.gradle"
 
 project.ext.override_dependencies = false
 

--- a/1.8.9/gradle/wrapper/gradle-wrapper.properties
+++ b/1.8.9/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Sep 14 12:28:28 PDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip


### PR DESCRIPTION
Improvements to 1.7's buildscript to make it easier to import and allow 1.8 to run on modern versions of IntelliJ